### PR TITLE
Add custom class parameter

### DIFF
--- a/src/angular-pickadate.js
+++ b/src/angular-pickadate.js
@@ -255,6 +255,7 @@
 
         link: function(scope, element, attrs, ngModel)  {
           var allowMultiple           = attrs.hasOwnProperty('multiple'),
+              customClass             = attrs.hasOwnProperty('customClass') ? attrs.customClass : '',
               selectedDates           = [],
               wantsModal              = element[0] instanceof HTMLInputElement,
               compiledHtml            = $compile(TEMPLATE)(scope),
@@ -341,7 +342,15 @@
             });
 
             element.after(compiledHtml.addClass('pickadate-modal'));
+
+            if (customClass) {
+              element.after(compiledHtml.addClass(customClass));
+            }
           } else {
+            if (customClass) {
+              element.after(compiledHtml.addClass(customClass));
+            }
+
             element.append(compiledHtml);
           }
 

--- a/test/angular-pickadate.spec.js
+++ b/test/angular-pickadate.spec.js
@@ -583,7 +583,7 @@ describe('pickadate', function () {
   describe('When used as a modal', function() {
 
     var inputHtml = '<form name="dateForm">' +
-                      '<input pickadate ng-model="date" min-date="minDate" type="text"></input>' +
+                      '<input pickadate ng-model="date" min-date="minDate" custom-class="pickadate-custom" type="text"></input>' +
                     '</form>',
         input, form;
 
@@ -596,8 +596,13 @@ describe('pickadate', function () {
       element = $('.pickadate');
     });
 
+
     it('adds the pickadate-modal class', function() {
       expect(element).to.have.class('pickadate-modal');
+    });
+
+    it('adds the pickadate-custom class', function() {
+      expect(element).to.have.class('pickadate-custom');
     });
 
     it('renders the datepicker already hidden', function() {


### PR DESCRIPTION
This PR add the possibility to add a custom class parameter to the pickadate directive.
Users could customize the calendar.

Exemple : 
```
<div pickadate custom-class="myCustomClass"></div>
```

Result :
```
<div class="pickadate myCustomClass" ...>...</div>
```

![capture d ecran 2015-09-02 10 42 27](https://cloud.githubusercontent.com/assets/2683300/9626649/5e7c9692-515f-11e5-8def-3f5cf1be58fc.png)
