### PR TITLE
bugfix: dateString can be empty

### DIFF
--- a/src/angular-pickadate.js
+++ b/src/angular-pickadate.js
@@ -111,7 +111,7 @@
         return {
 
           parseDate: function(dateString) {
-            if (!dateString) return;
+            if (!dateString || !dateString.length) return;
             if (angular.isDate(dateString)) return new Date(dateString);
 
             var formatRegex = '(dd|MM|yyyy)',


### PR DESCRIPTION
This eliminates an error when dateString has length=0.